### PR TITLE
Fix #23 - tck-coreprofile workflow guard and result aggregation

### DIFF
--- a/.github/workflows/tck-coreprofile.yml
+++ b/.github/workflows/tck-coreprofile.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   annotations:
-    if: github.repository == 'piranhacloud/piranha'
+    if: github.repository == 'eclipse-ee4j/piranha'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -36,7 +36,7 @@ jobs:
         paths: "test/tck/coreprofile/annotations/runner/target/failsafe-reports/*IT.xml"
       if: always()
   cdi:
-    if: github.repository == 'piranhacloud/piranha'
+    if: github.repository == 'eclipse-ee4j/piranha'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -63,7 +63,7 @@ jobs:
           cdi/runner/model/target/surefire-reports/TEST-*.xml
       if: always()
   coreprofile:
-    if: github.repository == 'piranhacloud/piranha'
+    if: github.repository == 'eclipse-ee4j/piranha'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -88,7 +88,7 @@ jobs:
         paths: "test/tck/coreprofile/coreprofile/runner/target/failsafe-reports/**/TEST-*.xml"
       if: always()
   inject:
-    if: github.repository == 'piranhacloud/piranha'
+    if: github.repository == 'eclipse-ee4j/piranha'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -113,7 +113,7 @@ jobs:
         paths: "test/tck/coreprofile/inject/installer/target/tck/example/target/surefire-reports/TEST-*.xml"
       if: always()      
   jsonb:
-    if: github.repository == 'piranhacloud/piranha'
+    if: github.repository == 'eclipse-ee4j/piranha'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -138,7 +138,7 @@ jobs:
         paths: "test/tck/coreprofile/jsonb/installer/target/tck/bin/target/surefire-reports/TEST-*.xml"
       if: always()
   jsonp:
-    if: github.repository == 'piranhacloud/piranha'
+    if: github.repository == 'eclipse-ee4j/piranha'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -165,7 +165,7 @@ jobs:
           test/tck/coreprofile/jsonp/installer/target/tck/bin/tck-tests-pluggability/target/surefire-reports/TEST-*.xml
       if: always()
   rest:
-    if: github.repository == 'piranhacloud/piranha'
+    if: github.repository == 'eclipse-ee4j/piranha'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -196,14 +196,29 @@ jobs:
         echo "${{ steps.test_summary.outputs.passed }} out of ${{ steps.test_summary.outputs.total }} tests passed" >> $GITHUB_STEP_SUMMARY
       if: always()
   result:
-    if: github.repository == 'piranhacloud/piranha'
+    if: github.repository == 'eclipse-ee4j/piranha'
     runs-on: ubuntu-latest
     needs: [annotations, cdi, coreprofile, inject, jsonb, jsonp, rest]
     steps:
       - name: Check build results
         run: |
-          result="${{ needs.build.result }}"
-          if [[ $result == "success" || $result == "skipped" ]]; then
+          results=(
+            "${{ needs.annotations.result }}"
+            "${{ needs.cdi.result }}"
+            "${{ needs.coreprofile.result }}"
+            "${{ needs.inject.result }}"
+            "${{ needs.jsonb.result }}"
+            "${{ needs.jsonp.result }}"
+            "${{ needs.rest.result }}"
+          )
+          failed=0
+          for result in "${results[@]}"; do
+            if [[ "$result" != "success" && "$result" != "skipped" ]]; then
+              failed=1
+              break
+            fi
+          done
+          if [[ $failed -eq 0 ]]; then
             echo "All TCK jobs were successful or skipped."
             exit 0
           else


### PR DESCRIPTION
## Summary
- Update tck-coreprofile workflow repo guard to eclipse-ee4j/piranha.
- Fix result job to aggregate the actual TCK jobs.

Fixes #23.

## Testing
- Not run (workflow-only change).
