### PR TITLE
Fix #25 - update workflow repo guards

### DIFF
--- a/.github/workflows/current.yml
+++ b/.github/workflows/current.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    if: github.repository == 'piranhacloud/piranha'
+    if: github.repository == 'eclipse-ee4j/piranha'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -26,7 +26,7 @@ jobs:
     - name: Build with Maven
       run: mvn -B -ntp -T 1 install
   docs:
-    if: github.repository == 'piranhacloud/piranha'
+    if: github.repository == 'eclipse-ee4j/piranha'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Piranha
@@ -56,7 +56,7 @@ jobs:
         git commit -a -m "Publishing SNAPSHOT documentation" || true
         git push
   ghcr:
-    if: github.repository == 'piranhacloud/piranha'
+    if: github.repository == 'eclipse-ee4j/piranha'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
@@ -122,7 +122,7 @@ jobs:
         cd dist/webprofile
         mvn -B -DskipTests=true -DskipITs=true -ntp -P docker deploy
   sonatype:
-    if: false # github.repository == 'piranhacloud/piranha'
+    if: false # github.repository == 'eclipse-ee4j/piranha'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    if: github.repository == 'piranhacloud/piranha'
+    if: github.repository == 'eclipse-ee4j/piranha'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -24,7 +24,7 @@ jobs:
     - name: Build with Maven
       run: mvn -B -ntp -T 1 install
   result:
-    if: ${{ always() }} && github.repository == 'piranhacloud/piranha'
+    if: ${{ always() }} && github.repository == 'eclipse-ee4j/piranha'
     runs-on: ubuntu-latest
     needs: build
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   stale:
-    if: github.repository == 'piranhacloud/piranha'
+    if: github.repository == 'eclipse-ee4j/piranha'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v10


### PR DESCRIPTION
## Summary
- Update workflow repo guards to eclipse-ee4j/piranha in current, experimental, and stale.
- Leave website repository references unchanged.

Fixes #25.

## Testing
- Not run (workflow-only change).
