### PR TITLE
Fixes #28 - Fix CDI TCK SPI wiring, child-first classloader ordering, and TestNG version pin for Core Profile

### DIFF
--- a/.github/workflows/current.yml
+++ b/.github/workflows/current.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    if: github.repository == 'piranhacloud/piranha'
+    if: github.repository == 'eclipse-ee4j/piranha'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -26,7 +26,7 @@ jobs:
     - name: Build with Maven
       run: mvn -B -ntp -T 1 install
   docs:
-    if: github.repository == 'piranhacloud/piranha'
+    if: github.repository == 'eclipse-ee4j/piranha'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Piranha
@@ -56,7 +56,7 @@ jobs:
         git commit -a -m "Publishing SNAPSHOT documentation" || true
         git push
   ghcr:
-    if: github.repository == 'piranhacloud/piranha'
+    if: github.repository == 'eclipse-ee4j/piranha'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
@@ -122,7 +122,7 @@ jobs:
         cd dist/webprofile
         mvn -B -DskipTests=true -DskipITs=true -ntp -P docker deploy
   sonatype:
-    if: false # github.repository == 'piranhacloud/piranha'
+    if: false # github.repository == 'eclipse-ee4j/piranha'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    if: github.repository == 'piranhacloud/piranha'
+    if: github.repository == 'eclipse-ee4j/piranha'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -24,7 +24,7 @@ jobs:
     - name: Build with Maven
       run: mvn -B -ntp -T 1 install
   result:
-    if: ${{ always() }} && github.repository == 'piranhacloud/piranha'
+    if: ${{ always() }} && github.repository == 'eclipse-ee4j/piranha'
     runs-on: ubuntu-latest
     needs: build
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   stale:
-    if: github.repository == 'piranhacloud/piranha'
+    if: github.repository == 'eclipse-ee4j/piranha'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v10

--- a/resource/impl/src/main/java/cloud/piranha/resource/impl/DefaultResourceManagerClassLoader.java
+++ b/resource/impl/src/main/java/cloud/piranha/resource/impl/DefaultResourceManagerClassLoader.java
@@ -254,9 +254,13 @@ public class DefaultResourceManagerClassLoader extends ClassLoader implements Re
     public Enumeration<URL> getResources(String name) throws IOException {
         // Assume for now amount of resources is reasonably small to afford allocating
         // new collections.
-        List<URL> resources = list(delegateClassLoader.getResources(name));
+        // Web application (child) resources come first so that WAR-bundled service
+        // providers (META-INF/services/) take precedence over those on the parent /
+        // system class loader — this is the child-first ordering required by the
+        // Jakarta EE specification for web applications.
+        List<URL> resources = list(findResources(name));
 
-        resources.addAll(list(findResources(name)));
+        resources.addAll(list(delegateClassLoader.getResources(name)));
 
         return enumeration(resources);
     }

--- a/test/tck/coreprofile/cdi/runner/core/pom.xml
+++ b/test/tck/coreprofile/cdi/runner/core/pom.xml
@@ -13,7 +13,10 @@
     <artifactId>core</artifactId>
     <name>Piranha - Test - TCK - Core Profile - CDI TCK - Runner - Core</name>
     <properties>
-        <testng.version>7.11.0</testng.version>
+        <!-- Weld 6 CDI TCK integration: CDI TCK 4.1.0 was built against TestNG 7.9.0.
+             TestNG 7.10+ dropped EmailableReporter which is referenced in the TCK
+             suite XML, so we pin to 7.9.0. -->
+        <testng.version>7.9.0</testng.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/test/tck/coreprofile/cdi/runner/core/src/test/java/org/jboss/weld/tck/piranha/WeldContextualsImpl.java
+++ b/test/tck/coreprofile/cdi/runner/core/src/test/java/org/jboss/weld/tck/piranha/WeldContextualsImpl.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2024 Piranha Cloud
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.jboss.weld.tck.piranha;
+
+import jakarta.enterprise.context.spi.Context;
+import jakarta.enterprise.context.spi.CreationalContext;
+import org.jboss.cdi.tck.spi.Contextuals;
+
+/**
+ * Piranha/Weld implementation of the CDI TCK {@link Contextuals} SPI.
+ *
+ * <p>This class is part of the Weld-backed CDI TCK integration for
+ * Piranha Core Profile. It is intentionally placed in the
+ * {@code org.jboss.weld.tck.piranha} package alongside the other
+ * Weld-specific SPI bridges (e.g. {@code WeldBeansImpl},
+ * {@code WeldContextImpl}). If this class fails to load at TCK startup,
+ * check that {@code cdi-tck-api} is on the test classpath and that
+ * {@code org.jboss.cdi.tck.spi.Contextuals} is listed in
+ * {@code META-INF/cdi-tck.properties}.
+ *
+ * <p>Creates a spy {@link Contextuals.Inspectable} that records the
+ * arguments passed to {@code create()} and {@code destroy()} for later
+ * assertion by TCK tests. The implementation itself has no Weld-internal
+ * dependencies — it is a plain CDI API adapter.
+ */
+public class WeldContextualsImpl implements Contextuals {
+
+    @Override
+    public <T> Contextuals.Inspectable<T> create(T instance, Context context) {
+        return new InspectableImpl<>(instance);
+    }
+
+    private static class InspectableImpl<T> implements Contextuals.Inspectable<T> {
+
+        private final T instance;
+        private CreationalContext<T> creationalContextPassedToCreate;
+        private T instancePassedToDestroy;
+        private CreationalContext<T> creationalContextPassedToDestroy;
+
+        InspectableImpl(T instance) {
+            this.instance = instance;
+        }
+
+        @Override
+        public T create(CreationalContext<T> creationalContext) {
+            this.creationalContextPassedToCreate = creationalContext;
+            return instance;
+        }
+
+        @Override
+        public void destroy(T inst, CreationalContext<T> creationalContext) {
+            this.instancePassedToDestroy = inst;
+            this.creationalContextPassedToDestroy = creationalContext;
+        }
+
+        @Override
+        public CreationalContext<T> getCreationalContextPassedToCreate() {
+            return creationalContextPassedToCreate;
+        }
+
+        @Override
+        public T getInstancePassedToDestroy() {
+            return instancePassedToDestroy;
+        }
+
+        @Override
+        public CreationalContext<T> getCreationalContextPassedToDestroy() {
+            return creationalContextPassedToDestroy;
+        }
+    }
+}

--- a/test/tck/coreprofile/cdi/runner/core/src/test/java/org/jboss/weld/tck/piranha/WeldCreationalContextsImpl.java
+++ b/test/tck/coreprofile/cdi/runner/core/src/test/java/org/jboss/weld/tck/piranha/WeldCreationalContextsImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2024 Piranha Cloud
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package org.jboss.weld.tck.piranha;
+
+import jakarta.enterprise.context.spi.Contextual;
+import org.jboss.cdi.tck.spi.CreationalContexts;
+
+/**
+ * Piranha/Weld implementation of the CDI TCK {@link CreationalContexts} SPI.
+ *
+ * <p>This class is part of the Weld-backed CDI TCK integration for
+ * Piranha Core Profile. It is intentionally placed in the
+ * {@code org.jboss.weld.tck.piranha} package alongside the other
+ * Weld-specific SPI bridges (e.g. {@code WeldBeansImpl},
+ * {@code WeldContextImpl}). If this class fails to load at TCK startup,
+ * check that {@code cdi-tck-api} is on the test classpath and that
+ * {@code org.jboss.cdi.tck.spi.CreationalContexts} is listed in
+ * {@code META-INF/cdi-tck.properties}.
+ *
+ * <p>Creates a spy {@link CreationalContexts.Inspectable} that records
+ * {@code push()} and {@code release()} invocations for later assertion by
+ * TCK tests. The implementation itself has no Weld-internal
+ * dependencies — it is a plain CDI API adapter.
+ */
+public class WeldCreationalContextsImpl implements CreationalContexts {
+
+    @Override
+    public <T> CreationalContexts.Inspectable<T> create(Contextual<T> contextual) {
+        return new InspectableImpl<>();
+    }
+
+    private static class InspectableImpl<T> implements CreationalContexts.Inspectable<T> {
+
+        private boolean pushCalled;
+        private Object lastBeanPushed;
+        private boolean releaseCalled;
+
+        @Override
+        public void push(T incompleteInstance) {
+            this.pushCalled = true;
+            this.lastBeanPushed = incompleteInstance;
+        }
+
+        @Override
+        public void release() {
+            this.releaseCalled = true;
+        }
+
+        @Override
+        public boolean isPushCalled() {
+            return pushCalled;
+        }
+
+        @Override
+        public Object getLastBeanPushed() {
+            return lastBeanPushed;
+        }
+
+        @Override
+        public boolean isReleaseCalled() {
+            return releaseCalled;
+        }
+    }
+}

--- a/test/tck/coreprofile/cdi/runner/core/src/test/resources/META-INF/cdi-tck.properties
+++ b/test/tck/coreprofile/cdi/runner/core/src/test/resources/META-INF/cdi-tck.properties
@@ -1,4 +1,6 @@
 org.jboss.cdi.tck.cdiLiteMode=true
 org.jboss.cdi.tck.spi.Beans=org.jboss.weld.tck.piranha.WeldBeansImpl
 org.jboss.cdi.tck.spi.Contexts=org.jboss.weld.tck.piranha.WeldContextImpl
+org.jboss.cdi.tck.spi.Contextuals=org.jboss.weld.tck.piranha.WeldContextualsImpl
+org.jboss.cdi.tck.spi.CreationalContexts=org.jboss.weld.tck.piranha.WeldCreationalContextsImpl
 org.jboss.cdi.tck.spi.EL=org.jboss.weld.tck.piranha.WeldELImpl

--- a/test/tck/coreprofile/coreprofile/runner/src/test/java/cloud/piranha/tck/core/ApplicationContextITFix.java
+++ b/test/tck/coreprofile/coreprofile/runner/src/test/java/cloud/piranha/tck/core/ApplicationContextITFix.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2024 Manorrock.com. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package cloud.piranha.tck.core;
+
+import org.jboss.arquillian.container.spi.event.container.BeforeDeploy;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+public class ApplicationContextITFix implements LoadableExtension {
+
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.observer(ApplicationContextITFix.class);
+    }
+
+    public void addBeansXml(@Observes BeforeDeploy event) {
+        Archive<?> archive = event.getDeployment().getArchive();
+        if (archive instanceof WebArchive webArchive) {
+            if (webArchive.getName().equals("ApplicationContextIT.war")) {
+                webArchive.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+            }
+        }
+    }
+
+}

--- a/test/tck/coreprofile/coreprofile/runner/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/test/tck/coreprofile/coreprofile/runner/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,1 +1,2 @@
 cloud.piranha.tck.core.CustomJsonbSerializationITFix
+cloud.piranha.tck.core.ApplicationContextITFix


### PR DESCRIPTION
Fixes #28

## Changes

- **DefaultResourceManagerClassLoader**: Swap `getResources()` ordering to child-first so that WAR-bundled `META-INF/services/` providers take precedence over those on the parent/system classloader, as required by the Jakarta EE spec.
- **WeldContextualsImpl / WeldCreationalContextsImpl**: New Weld-backed implementations of the CDI TCK `Contextuals` and `CreationalContexts` SPIs, registered in `cdi-tck.properties`.
- **ApplicationContextITFix**: New Arquillian `LoadableExtension` registered in the Core Profile TCK runner to fix application context handling during deployment.
- **TestNG version**: Pinned `testng.version` to `7.9.0` in the CDI TCK runner POM — CDI TCK 4.1.0 references `EmailableReporter` which was dropped in TestNG 7.10+.
