### PR TITLE
Fixes #30 - Serve 503 on deployment failure instead of exiting

### DIFF
--- a/arquillian/managed/src/main/java/cloud/piranha/arquillian/managed/ManagedPiranhaContainer.java
+++ b/arquillian/managed/src/main/java/cloud/piranha/arquillian/managed/ManagedPiranhaContainer.java
@@ -30,8 +30,13 @@ package cloud.piranha.arquillian.managed;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.file.Files;
+import java.time.Duration;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -91,6 +96,12 @@ public class ManagedPiranhaContainer implements DeployableContainer<ManagedPiran
      * Stores the Piranha process.
      */
     private Process process;
+
+    /**
+     * Stores the Piranha instance log file for the current deployment.
+     * Set during {@link #startPiranha} so it can be surfaced after undeploy.
+     */
+    private File logFile;
 
     /**
      * Default constructor.
@@ -191,6 +202,17 @@ public class ManagedPiranhaContainer implements DeployableContainer<ManagedPiran
                 LOGGER.log(WARNING, "Piranha did not shutdown within time alloted");
                 LOGGER.log(WARNING, "Destroying Piranha process forcibly");
                 process.destroyForcibly();
+            }
+        }
+
+        /*
+         * Log the Piranha instance output to help diagnose test failures.
+         */
+        if (logFile != null && logFile.exists()) {
+            try {
+                LOGGER.log(INFO, "Piranha log ({0}):\n{1}", logFile.getAbsolutePath(), Files.readString(logFile.toPath()));
+            } catch (IOException ioe) {
+                LOGGER.log(WARNING, "Could not read Piranha log file: {0}", ioe.getMessage());
             }
         }
 
@@ -417,7 +439,7 @@ public class ManagedPiranhaContainer implements DeployableContainer<ManagedPiran
 
         String appName = toAppName(warFile.getName());
         String appURL = "http://localhost:" + Integer.toString(configuration.getHttpPort()) + "/" + appName;
-        File logFile = new File(runtimeDirectory, appName + ".log");
+        logFile = new File(runtimeDirectory, appName + ".log");
 
         LOGGER.log(INFO,
             """
@@ -476,11 +498,38 @@ public class ManagedPiranhaContainer implements DeployableContainer<ManagedPiran
             LOGGER.log(WARNING, "Piranha terminated during startup.");
 
             String msg = "Cannot start Piranha. \n";
-            if (process.getErrorStream() != null) {
+            if (logFile.exists()) {
                 msg += Files.readString(logFile.toPath());
             }
 
             throw new DeploymentException(msg);
+        }
+
+        /*
+         * HTTP probe: if Piranha returns 503, the WAR failed to deploy.
+         * The response body carries the deployment exception message.
+         */
+        try {
+            HttpClient httpClient = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(5))
+                    .build();
+            HttpRequest probeRequest = HttpRequest.newBuilder()
+                    .uri(URI.create(appURL))
+                    .timeout(Duration.ofSeconds(5))
+                    .GET()
+                    .build();
+            HttpResponse<String> probeResponse = httpClient.send(
+                    probeRequest, HttpResponse.BodyHandlers.ofString());
+            if (probeResponse.statusCode() == 503) {
+                throw new DeploymentException(probeResponse.body());
+            }
+        } catch (DeploymentException de) {
+            throw de;
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(WARNING, "HTTP probe interrupted");
+        } catch (Exception e) {
+            LOGGER.log(WARNING, "HTTP probe failed, proceeding: {0}", e.getMessage());
         }
 
         LOGGER.log(INFO,

--- a/arquillian/managed/src/main/java/module-info.java
+++ b/arquillian/managed/src/main/java/module-info.java
@@ -42,5 +42,6 @@ module cloud.piranha.arquillian.managed {
     requires arquillian.container.spi;
     requires arquillian.core.spi;
     requires free.port.finder;
+    requires java.net.http;
     requires shrinkwrap.api;
 }

--- a/feature/webapp/src/main/java/cloud/piranha/feature/webapp/WebAppFeature.java
+++ b/feature/webapp/src/main/java/cloud/piranha/feature/webapp/WebAppFeature.java
@@ -27,6 +27,7 @@
  */
 package cloud.piranha.feature.webapp;
 
+import cloud.piranha.core.api.WebApplication;
 import cloud.piranha.core.api.WebApplicationExtension;
 import cloud.piranha.core.impl.DefaultModuleFinder;
 import cloud.piranha.core.impl.DefaultModuleLayerProcessor;
@@ -95,6 +96,11 @@ public class WebAppFeature extends DefaultFeature {
     private HttpWebApplicationServer httpWebApplicationServer;
 
     /**
+     * Stores the deployment error, if any.
+     */
+    private Throwable deploymentError;
+
+    /**
      * Constructor.
      */
     public WebAppFeature() {
@@ -116,6 +122,15 @@ public class WebAppFeature extends DefaultFeature {
      */
     public Class<? extends WebApplicationExtension> getExtensionClass() {
         return extensionClass;
+    }
+
+    /**
+     * Get the deployment error.
+     *
+     * @return the deployment error, or null if deployment succeeded.
+     */
+    public Throwable getDeploymentError() {
+        return deploymentError;
     }
 
     /**
@@ -202,12 +217,13 @@ public class WebAppFeature extends DefaultFeature {
                 contextPath = "/" + contextPath;
             }
             webApplication.setContextPath(contextPath);
-            httpWebApplicationServer.addWebApplication(webApplication);
-
-            try {
-                webApplication.initialize();
-            } catch (Throwable e) {
-                LOGGER.log(ERROR, "Failed to initialize web application");
+            webApplication.initialize();
+            if (webApplication.getStatus() == WebApplication.Status.ERROR) {
+                deploymentError = new RuntimeException(
+                    "Web application initialization failed (status=ERROR) at " + contextPath);
+                LOGGER.log(ERROR, "Failed to initialize web application at {0}", contextPath);
+            } else {
+                httpWebApplicationServer.addWebApplication(webApplication);
             }
         }
 

--- a/single/src/main/java/cloud/piranha/single/SinglePiranha.java
+++ b/single/src/main/java/cloud/piranha/single/SinglePiranha.java
@@ -32,6 +32,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
 
 import cloud.piranha.core.api.Piranha;
 import cloud.piranha.core.api.PiranhaConfiguration;
@@ -45,6 +46,7 @@ import cloud.piranha.feature.impl.DefaultFeatureManager;
 import cloud.piranha.feature.logging.LoggingFeature;
 import cloud.piranha.feature.webapp.WebAppFeature;
 import cloud.piranha.http.api.HttpServer;
+import cloud.piranha.http.api.HttpServerProcessorEndState;
 
 import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.INFO;
@@ -140,6 +142,8 @@ public class SinglePiranha implements Piranha, Runnable {
         webAppFeature.start();
         featureManager.addFeature(webAppFeature);
 
+        Throwable deploymentError = webAppFeature.getDeploymentError();
+
         /*
          * Construct, initialize and start HTTP endpoint (if applicable).
          */
@@ -148,7 +152,26 @@ public class SinglePiranha implements Piranha, Runnable {
             httpFeature.setHttpServerClass(configuration.getString("httpServerClass"));
             httpFeature.setPort(configuration.getInteger("httpPort"));
             httpFeature.init();
-            httpFeature.getHttpServer().setHttpServerProcessor(webAppFeature.getHttpServerProcessor());
+            if (deploymentError != null) {
+                final String errorBody = deploymentError.toString();
+                httpFeature.getHttpServer().setHttpServerProcessor((request, response) -> {
+                    try {
+                        byte[] body = errorBody.getBytes(StandardCharsets.UTF_8);
+                        response.setStatus(503);
+                        response.setHeader("Content-Type", "text/plain;charset=UTF-8");
+                        response.setHeader("Content-Length", Integer.toString(body.length));
+                        response.writeStatusLine();
+                        response.writeHeaders();
+                        response.getOutputStream().write(body);
+                        response.getOutputStream().flush();
+                    } catch (IOException ioe) {
+                        LOGGER.log(WARNING, "Could not write 503 response", ioe);
+                    }
+                    return HttpServerProcessorEndState.COMPLETED;
+                });
+            } else {
+                httpFeature.getHttpServer().setHttpServerProcessor(webAppFeature.getHttpServerProcessor());
+            }
 
             /*
              * Enable Project CRaC.
@@ -186,7 +209,26 @@ public class SinglePiranha implements Piranha, Runnable {
             httpsFeature.setHttpsTruststorePassword(configuration.getString("httpsTruststorePassword"));
             httpsFeature.setPort(configuration.getInteger("httpsPort"));
             httpsFeature.init();
-            httpsFeature.getHttpsServer().setHttpServerProcessor(webAppFeature.getHttpServerProcessor());
+            if (deploymentError != null) {
+                final String errorBody = deploymentError.toString();
+                httpsFeature.getHttpsServer().setHttpServerProcessor((request, response) -> {
+                    try {
+                        byte[] body = errorBody.getBytes(StandardCharsets.UTF_8);
+                        response.setStatus(503);
+                        response.setHeader("Content-Type", "text/plain;charset=UTF-8");
+                        response.setHeader("Content-Length", Integer.toString(body.length));
+                        response.writeStatusLine();
+                        response.writeHeaders();
+                        response.getOutputStream().write(body);
+                        response.getOutputStream().flush();
+                    } catch (IOException ioe) {
+                        LOGGER.log(WARNING, "Could not write 503 response", ioe);
+                    }
+                    return HttpServerProcessorEndState.COMPLETED;
+                });
+            } else {
+                httpsFeature.getHttpsServer().setHttpServerProcessor(webAppFeature.getHttpServerProcessor());
+            }
 
             /*
              * Enable Project CRaC.


### PR DESCRIPTION
## Summary

When a WAR deployment fails (e.g. CDI `DeploymentException` or `DefinitionException`
during Weld initialization), Piranha currently exits the process without writing
the PID file. The Arquillian managed container then polls for up to 120 seconds
before giving up, making every deployment-failure TCK test take ~120 s.

This PR keeps Piranha alive on deployment failure, starts HTTP, and returns
`503 Service Unavailable` with the exception message in the response body. The
Arquillian connector detects the `503` and immediately throws a
`DeploymentException` whose message contains the original CDI error text, which
`PiranhaDeploymentExceptionTransformer` already knows how to map to the correct
CDI spec exception type (`jakarta.enterprise.inject.spi.DeploymentException` /
`DefinitionException`).

## Changes

### `feature/webapp/WebAppFeature` — detect initialization failure

`DefaultWebApplication.initialize()` does not throw on CDI failure; it sets its
status to `ERROR`. After `initialize()` we now check the status:

- `ERROR` → store the exception as `deploymentError`, do **not** register the
  app in `HttpWebApplicationServer`
- success → register as before

The `deploymentError` is exposed via `getDeploymentError()`.

### `single/SinglePiranha` — serve 503 when deployment failed

After `webAppFeature.start()`, if `getDeploymentError() != null` the HTTP (and
HTTPS) processor is replaced with a lambda that always returns:

```
HTTP/1.1 503 Service Unavailable
Content-Type: text/plain;charset=UTF-8

<exception.toString()>
```

All other startup steps (HTTP port bind, PID file write) proceed normally, so
the connector unblocks immediately.

### `arquillian/managed/ManagedPiranhaContainer` — HTTP probe after PID

After the PID file appears the connector fires one HTTP `GET` to the app URL:

```java
if (probeResponse.statusCode() == 503) {
    throw new DeploymentException(probeResponse.body());
}
```

Any other status code (including `500` from a buggy app) is treated as success.
The `503` body is the CDI exception message, which
`PiranhaDeploymentExceptionTransformer` scans for known fragments.

### `arquillian/managed/module-info.java`

Added `requires java.net.http;` for `HttpClient`.

## Effect on CDI TCK

Deployment-failure tests that previously waited ~120 s each now complete in
~2 s. The `PiranhaDeploymentExceptionTransformer` matches the exception message
from the response body in exactly the same way it matched the process log before.
