### PR TITLE
Disable docs and ghcr jobs in current workflow

### DIFF
--- a/.github/workflows/current.yml
+++ b/.github/workflows/current.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Build with Maven
       run: mvn -B -ntp -T 1 install
   docs:
-    if: github.repository == 'eclipse-ee4j/piranha'
+    if: false # github.repository == 'eclipse-ee4j/piranha'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Piranha
@@ -56,7 +56,7 @@ jobs:
         git commit -a -m "Publishing SNAPSHOT documentation" || true
         git push
   ghcr:
-    if: github.repository == 'eclipse-ee4j/piranha'
+    if: false # github.repository == 'eclipse-ee4j/piranha'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources


### PR DESCRIPTION
Closes #32\n\nThe `docs` and `ghcr` jobs in the `current` workflow are currently not working. This PR disables them by setting `if: false`, consistent with how the `sonatype` job is already disabled.\n\nAffected jobs:\n- `docs` — publishes SNAPSHOT documentation to piranha-website\n- `ghcr` — builds and pushes Docker images to GHCR