### PR TITLE
Mention ECA in Contributing, allow Eclipse Foundation copyright in header

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,20 @@ involvement you are aiming for. The following comes to mind:
 
 Which ever level you pick we welcome you!
 
-## Important notice
+## Eclipse Contributor Agreement
 
-Note if you file issues, answer questions and/or issue pull requests you agree
-that those contributions will be owned by Manorrock.com and that Manorrock.com 
-can use those contributions in any manner Manorrock.com so desires.
+Before your contribution can be accepted by the project team, contributors must
+electronically sign the Eclipse Contributor Agreement (ECA).
+
+* http://www.eclipse.org/legal/ECA.php
+
+Git commit records are required to take a specific form.
+The credentials of the actual author must be used to populate the Author field.
+The author credentials must specify the author’s actual (legal) name and email address.
+The email address used must match the email address that the Eclipse Foundation has on file for the author (case-sensitive).
+
+For more information, please see the Eclipse Committer Handbook:
+https://www.eclipse.org/projects/handbook/#resources-commit
 
 ## Building and testing Piranha locally
 

--- a/embedded/src/site/markdown/create_an_embedded_jlink_application.md
+++ b/embedded/src/site/markdown/create_an_embedded_jlink_application.md
@@ -95,7 +95,7 @@ Create an empty directory to store your Maven project. Inside of that directory 
                     <jreleaser>
                         <project>
                             <description>${project.name}</description>
-                            <copyright>Manorrock.com</copyright>
+                            <copyright>Contributors to the Eclipse Foundation</copyright>
                         </project>
                         <assemble>
                             <jlink>

--- a/pom.xml
+++ b/pom.xml
@@ -808,9 +808,9 @@
                     <checkstyleRules>
                         <module name="Checker">
                             <property name="fileExtensions" value="java"/>
-                            <module name="Header">
+                            <module name="RegexpHeader">
                                 <property name="header"
-                                          value="/*\n * Copyright (c) 2002-2025 Manorrock.com. All Rights Reserved.\n *"/>
+                                          value="/\*\n \* Copyright \(c\) (2002-2025 Manorrock\.com\. All Rights Reserved\.|\d{4}([-,]\d{4})* Contributors to the Eclipse Foundation\.)"/>
                             </module>
                             <module name="SuppressWarningsFilter"/>
                             <module name="TreeWalker">


### PR DESCRIPTION
This is now Eclipse Foundation project, this aligns it with Eclipse Foundation rules.


----------------------------------
@mnriem, what about the license? 

The Eclipse Foundation project page states that the license is EPL: https://projects.eclipse.org/projects/ee4j.piranha.

But the source code contains BSD license: https://github.com/eclipse-ee4j/piranha/blob/current/LICENSE and headers of all source files.